### PR TITLE
Setup admin user, roles, and dashboard

### DIFF
--- a/backend/database/migrations/2026_04_09_210757_add_fields_to_users_table.php
+++ b/backend/database/migrations/2026_04_09_210757_add_fields_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('username')->unique()->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('cognito_sub')->nullable();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->json('profile_metadata')->nullable();
+            $table->enum('role', ['admin', 'user'])->default('user');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/backend/database/seeders/AdminUserSeeder.php
+++ b/backend/database/seeders/AdminUserSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class AdminUserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::create([
+            'name' => 'Bci Admin',
+            'email' => 'webDevAdmin@bcimedia.com',
+            'password' => Hash::make('bciadminpassword123!'),
+            'role' => 'admin',
+        ]);
+    }
+}

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -2,24 +2,15 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    use WithoutModelEvents;
-
     /**
      * Seed the application's database.
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(AdminUserSeeder::class);
     }
 }

--- a/backend/resources/views/dashboard.blade.php
+++ b/backend/resources/views/dashboard.blade.php
@@ -1,17 +1,25 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ __('Dashboard') }}
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Dashboard
         </h2>
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 dark:text-gray-100">
-                    {{ __("You're logged in!") }}
-                </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p>Welcome to the dashboard.</p>
+
+                <p class="mt-2">
+                    Logged in as: {{ auth()->user()->email }}
+                </p>
+
+                <p class="mt-2">
+                    Role: {{ auth()->user()->role }}
+                </p>
             </div>
+
         </div>
     </div>
 </x-app-layout>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -3,18 +3,39 @@
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
+/*
+|--------------------------------------------------------------------------
+| Public Routes
+|--------------------------------------------------------------------------
+*/
+
 Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+/*
+|--------------------------------------------------------------------------
+| Authenticated Routes
+|--------------------------------------------------------------------------
+*/
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth'])->group(function () {
+
+    // Dashboard
+    Route::get('/dashboard', function () {
+        return view('dashboard');
+    })->name('dashboard');
+
+    // Profile (Breeze default)
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Auth Routes (Login / Register)
+|--------------------------------------------------------------------------
+*/
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Overview

This PR builds on the initial authentication setup by introducing user roles, an admin user, and a protected dashboard.

## Changes

- Extended users table to include:
  - role
  - username
  - profile-related fields
- Added AdminUserSeeder to create a master admin account
- Removed default test user seeding
- Implemented protected /dashboard route
- Created dashboard view using Blade layout
- Configured authentication redirect to dashboard after login

## Notes

- Dashboard is currently a placeholder for future features
- Role system is in place but not yet enforced via middleware
- This establishes the foundation for permission-based access control

## Next Steps

- Implement admin middleware and role-based access restrictions
- Begin building image upload and management system